### PR TITLE
refactor: ステップ番号をコンポーネント名から削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Next.js + TypeScript + shadcn/ui + Zod を使用した高度な複数ステッ�
 - **リアルタイムバリデーション**: 入力時のエラークリア機能
 
 ### 🏗️ 保守性とテスト性
-- **コンポーネント分割**: Step1PersonalInfo、Step2ContactInfo、Step3Confirmation
+- **コンポーネント分割**: PersonalInfo、ContactInfo、Confirmation
 - **共通型定義**: step-form-types.tsによる一元管理
 - **テスト対応**: data-testid属性とテストサンプルコード
 - **包括的テスト例**: Zodスキーマとバリデーション関数のテストカバー
@@ -71,9 +71,9 @@ src/
 │   │   ├── label.tsx               # shadcn/ui Label
 │   │   └── checkbox.tsx            # shadcn/ui Checkbox
 │   └── step-form/
-│       ├── step1-personal-info.tsx # ステップ1: 氏名入力
-│       ├── step2-contact-info.tsx  # ステップ2: 住所・電話・同意
-│       └── step3-confirmation.tsx  # ステップ3: 確認画面
+│       ├── personal-info.tsx       # 個人情報: 氏名入力
+│       ├── contact-info.tsx        # 連絡先情報: 住所・電話・同意
+│       └── confirmation.tsx        # 確認画面
 ├── lib/
 │   ├── step-form-types.ts          # Zodスキーマと型定義
 │   └── utils.ts                    # ユーティリティ関数
@@ -114,6 +114,14 @@ export const formDataSchema = z.object({
   agreement: z.boolean().refine(val => val === true, {
     message: "利用規約への同意が必要です",
   }),
+});
+
+// コンポーネント別スキーマ
+export const personalInfoSchema = formDataSchema.pick({
+  firstName: true, lastName: true
+});
+export const contactInfoSchema = formDataSchema.pick({
+  address: true, phone: true, agreement: true
 });
 
 // 型安全な自動生成型
@@ -158,8 +166,8 @@ npm run lint
 
 プロジェクトには包括的なテストサンプルが含まれています（`src/__tests__/step-form.test.example.ts`）：
 
-- **スキーマレベルテスト**: formDataSchema、step1Schema、step2Schemaの直接テスト
-- **バリデーション関数テスト**: validateStep1、validateStep2、validateFormDataのテスト
+- **スキーマレベルテスト**: formDataSchema、personalInfoSchema、contactInfoSchemaの直接テスト
+- **バリデーション関数テスト**: validatePersonalInfo、validateContactInfo、validateFormDataのテスト
 - **コンポーネントテスト例**: React Testing Libraryを使用したUIテストのサンプル
 
 ### 実際のテスト環境セットアップ

--- a/src/__tests__/step-form.test.example.ts
+++ b/src/__tests__/step-form.test.example.ts
@@ -3,12 +3,12 @@
 
 import {
   FormData,
-  validateStep1,
-  validateStep2,
+  validatePersonalInfo,
+  validateContactInfo,
   validateFormData,
   formDataSchema,
-  step1Schema,
-  step2Schema,
+  personalInfoSchema,
+  contactInfoSchema,
   validatePhone,
 } from "@/lib/step-form-types";
 
@@ -50,48 +50,48 @@ describe("Zod Schema Validation", () => {
     });
   });
 
-  describe("step1Schema", () => {
-    it("should validate step1 data", () => {
-      const validStep1: { firstName: string; lastName: string } = {
+  describe("personalInfoSchema", () => {
+    it("should validate personal info data", () => {
+      const validPersonalInfo: { firstName: string; lastName: string } = {
         firstName: "山田",
         lastName: "太郎",
       };
 
-      const result = step1Schema.safeParse(validStep1);
+      const result = personalInfoSchema.safeParse(validPersonalInfo);
       expect(result.success).toBe(true);
     });
 
-    it("should reject invalid step1 data", () => {
-      const invalidStep1 = {
+    it("should reject invalid personal info data", () => {
+      const invalidPersonalInfo = {
         firstName: "",
         lastName: "",
       };
 
-      const result = step1Schema.safeParse(invalidStep1);
+      const result = personalInfoSchema.safeParse(invalidPersonalInfo);
       expect(result.success).toBe(false);
     });
   });
 
-  describe("step2Schema", () => {
-    it("should validate step2 data", () => {
-      const validStep2 = {
+  describe("contactInfoSchema", () => {
+    it("should validate contact info data", () => {
+      const validContactInfo = {
         address: "東京都渋谷区1-1-1",
         phone: "090-1234-5678",
         agreement: true,
       };
 
-      const result = step2Schema.safeParse(validStep2);
+      const result = contactInfoSchema.safeParse(validContactInfo);
       expect(result.success).toBe(true);
     });
 
-    it("should reject invalid step2 data", () => {
-      const invalidStep2 = {
+    it("should reject invalid contact info data", () => {
+      const invalidContactInfo = {
         address: "",
         phone: "123",
         agreement: false,
       };
 
-      const result = step2Schema.safeParse(invalidStep2);
+      const result = contactInfoSchema.safeParse(invalidContactInfo);
       expect(result.success).toBe(false);
     });
   });
@@ -99,7 +99,7 @@ describe("Zod Schema Validation", () => {
 
 // バリデーション関数のテスト例（Zodベース）
 describe("Zod-based Step Form Validation", () => {
-  describe("validateStep1", () => {
+  describe("validatePersonalInfo", () => {
     it("should return no errors for valid input", () => {
       const formData: FormData = {
         firstName: "山田",
@@ -109,7 +109,7 @@ describe("Zod-based Step Form Validation", () => {
         agreement: false,
       };
 
-      const errors = validateStep1(formData);
+      const errors = validatePersonalInfo(formData);
       expect(Object.keys(errors)).toHaveLength(0);
     });
 
@@ -122,7 +122,7 @@ describe("Zod-based Step Form Validation", () => {
         agreement: false,
       };
 
-      const errors = validateStep1(formData);
+      const errors = validatePersonalInfo(formData);
       expect(errors.firstName).toBe("姓を入力してください");
     });
 
@@ -135,7 +135,7 @@ describe("Zod-based Step Form Validation", () => {
         agreement: false,
       };
 
-      const errors = validateStep1(formData);
+      const errors = validatePersonalInfo(formData);
       expect(errors.lastName).toBe("名を入力してください");
     });
 
@@ -148,13 +148,13 @@ describe("Zod-based Step Form Validation", () => {
         agreement: true,
       };
 
-      const errors = validateStep1(formData);
+      const errors = validatePersonalInfo(formData);
       expect(errors.firstName).toBe("姓を入力してください");
       expect(errors.lastName).toBe("名を入力してください");
     });
   });
 
-  describe("validateStep2", () => {
+  describe("validateContactInfo", () => {
     it("should return no errors for valid input", () => {
       const formData: FormData = {
         firstName: "山田",
@@ -164,7 +164,7 @@ describe("Zod-based Step Form Validation", () => {
         agreement: true,
       };
 
-      const errors = validateStep2(formData);
+      const errors = validateContactInfo(formData);
       expect(Object.keys(errors)).toHaveLength(0);
     });
 
@@ -177,7 +177,7 @@ describe("Zod-based Step Form Validation", () => {
         agreement: true,
       };
 
-      const errors = validateStep2(formData);
+      const errors = validateContactInfo(formData);
       expect(errors.phone).toBe("正しい電話番号の形式で入力してください（例: 090-1234-5678）");
     });
 
@@ -190,7 +190,7 @@ describe("Zod-based Step Form Validation", () => {
         agreement: false,
       };
 
-      const errors = validateStep2(formData);
+      const errors = validateContactInfo(formData);
       expect(errors.agreement).toBe("利用規約への同意が必要です");
     });
 
@@ -203,7 +203,7 @@ describe("Zod-based Step Form Validation", () => {
         agreement: false,
       };
 
-      const errors = validateStep2(formData);
+      const errors = validateContactInfo(formData);
       expect(errors.address).toBe("住所を入力してください");
       expect(errors.phone).toBe("正しい電話番号の形式で入力してください（例: 090-1234-5678）");
       expect(errors.agreement).toBe("利用規約への同意が必要です");
@@ -268,10 +268,10 @@ describe("Zod-based Step Form Validation", () => {
 // コンポーネントテストの例（React Testing Libraryを使用）
 /*
 import { render, screen, fireEvent } from "@testing-library/react";
-import { Step1PersonalInfo } from "@/components/step-form/step1-personal-info";
+import { PersonalInfo } from "@/components/step-form/personal-info";
 import { FormData, ValidationErrors } from "@/lib/step-form-types";
 
-describe("Step1PersonalInfo", () => {
+describe("PersonalInfo", () => {
   const mockFormData: FormData = {
     firstName: "",
     lastName: "",
@@ -289,7 +289,7 @@ describe("Step1PersonalInfo", () => {
 
   it("should render input fields", () => {
     render(
-      <Step1PersonalInfo
+      <PersonalInfo
         formData={mockFormData}
         errors={mockErrors}
         onUpdateField={mockOnUpdateField}
@@ -302,7 +302,7 @@ describe("Step1PersonalInfo", () => {
 
   it("should call onUpdateField when firstName changes", () => {
     render(
-      <Step1PersonalInfo
+      <PersonalInfo
         formData={mockFormData}
         errors={mockErrors}
         onUpdateField={mockOnUpdateField}
@@ -321,7 +321,7 @@ describe("Step1PersonalInfo", () => {
     };
 
     render(
-      <Step1PersonalInfo
+      <PersonalInfo
         formData={mockFormData}
         errors={errorsWithMessage}
         onUpdateField={mockOnUpdateField}
@@ -337,7 +337,7 @@ describe("Step1PersonalInfo", () => {
     };
 
     render(
-      <Step1PersonalInfo
+      <PersonalInfo
         formData={mockFormData}
         errors={errorsWithMessage}
         onUpdateField={mockOnUpdateField}

--- a/src/components/step-form/confirmation.tsx
+++ b/src/components/step-form/confirmation.tsx
@@ -1,7 +1,7 @@
 import { StepComponentProps } from "@/lib/step-form-types";
 import { cn } from "@/lib/utils";
 
-export function Step3Confirmation({ 
+export function Confirmation({ 
   formData, 
   className 
 }: StepComponentProps) {

--- a/src/components/step-form/contact-info.tsx
+++ b/src/components/step-form/contact-info.tsx
@@ -4,7 +4,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { StepComponentProps } from "@/lib/step-form-types";
 import { cn } from "@/lib/utils";
 
-export function Step2ContactInfo({ 
+export function ContactInfo({ 
   formData, 
   errors, 
   onUpdateField, 

--- a/src/components/step-form/index.ts
+++ b/src/components/step-form/index.ts
@@ -1,3 +1,3 @@
-export { Step1PersonalInfo } from "./step1-personal-info";
-export { Step2ContactInfo } from "./step2-contact-info";
-export { Step3Confirmation } from "./step3-confirmation";
+export { PersonalInfo } from "./personal-info";
+export { ContactInfo } from "./contact-info";
+export { Confirmation } from "./confirmation";

--- a/src/components/step-form/personal-info.tsx
+++ b/src/components/step-form/personal-info.tsx
@@ -3,7 +3,7 @@ import { Label } from "@/components/ui/label";
 import { StepComponentProps } from "@/lib/step-form-types";
 import { cn } from "@/lib/utils";
 
-export function Step1PersonalInfo({ 
+export function PersonalInfo({ 
   formData, 
   errors, 
   onUpdateField, 

--- a/src/components/ui/step-dialog.tsx
+++ b/src/components/ui/step-dialog.tsx
@@ -11,15 +11,15 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import {
-  Step1PersonalInfo,
-  Step2ContactInfo,
-  Step3Confirmation,
+  PersonalInfo,
+  ContactInfo,
+  Confirmation,
 } from "@/components/step-form";
 import {
   FormData,
   ValidationErrors,
-  validateStep1,
-  validateStep2,
+  validatePersonalInfo,
+  validateContactInfo,
   getStepTitle,
   getStepDescription,
 } from "@/lib/step-form-types";
@@ -53,9 +53,9 @@ export function StepDialog({ trigger }: StepDialogProps) {
     let newErrors: ValidationErrors = {};
     
     if (step === 1) {
-      newErrors = validateStep1(formData);
+      newErrors = validatePersonalInfo(formData);
     } else if (step === 2) {
-      newErrors = validateStep2(formData);
+      newErrors = validateContactInfo(formData);
     }
     
     setErrors(newErrors);
@@ -119,11 +119,11 @@ export function StepDialog({ trigger }: StepDialogProps) {
 
     switch (currentStep) {
       case 1:
-        return <Step1PersonalInfo {...stepProps} />;
+        return <PersonalInfo {...stepProps} />;
       case 2:
-        return <Step2ContactInfo {...stepProps} />;
+        return <ContactInfo {...stepProps} />;
       case 3:
-        return <Step3Confirmation {...stepProps} />;
+        return <Confirmation {...stepProps} />;
       default:
         return null;
     }

--- a/src/components/ui/step-dialog.tsx
+++ b/src/components/ui/step-dialog.tsx
@@ -10,9 +10,11 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { Step1PersonalInfo } from "@/components/step-form/step1-personal-info";
-import { Step2ContactInfo } from "@/components/step-form/step2-contact-info";
-import { Step3Confirmation } from "@/components/step-form/step3-confirmation";
+import {
+  Step1PersonalInfo,
+  Step2ContactInfo,
+  Step3Confirmation,
+} from "@/components/step-form";
 import {
   FormData,
   ValidationErrors,
@@ -86,8 +88,8 @@ export function StepDialog({ trigger }: StepDialogProps) {
   };
 
   const handleClose = () => {
-    setOpen(false);
     resetForm();
+    setOpen(false);
   };
 
   const handleSubmit = async () => {
@@ -167,6 +169,7 @@ export function StepDialog({ trigger }: StepDialogProps) {
           {renderStepContent()}
         </div>
 
+        {/* DialogFooter だと右側にボタンが寄ってしまうので、カスタムフッターを使用 */}
         <div className="flex justify-between items-center pt-4 border-t">
           {/* 左端：キャンセルボタン */}
           <Button variant="outline" onClick={handleClose} disabled={isLoading}>

--- a/src/lib/step-form-types.ts
+++ b/src/lib/step-form-types.ts
@@ -22,14 +22,14 @@ export const formDataSchema = z.object({
   }),
 });
 
-// ステップ1のスキーマ（姓名のみ）
-export const step1Schema = formDataSchema.pick({
+// 個人情報のスキーマ（姓名のみ）
+export const personalInfoSchema = formDataSchema.pick({
   firstName: true,
   lastName: true,
 });
 
-// ステップ2のスキーマ（住所、電話、同意）
-export const step2Schema = formDataSchema.pick({
+// 連絡先情報のスキーマ（住所、電話、同意）
+export const contactInfoSchema = formDataSchema.pick({
   address: true,
   phone: true,
   agreement: true,
@@ -37,8 +37,8 @@ export const step2Schema = formDataSchema.pick({
 
 // 型定義をスキーマから自動生成
 export type FormData = z.infer<typeof formDataSchema>;
-export type Step1Data = z.infer<typeof step1Schema>;
-export type Step2Data = z.infer<typeof step2Schema>;
+export type PersonalInfoData = z.infer<typeof personalInfoSchema>;
+export type ContactInfoData = z.infer<typeof contactInfoSchema>;
 
 // バリデーションエラー型
 export interface ValidationErrors {
@@ -73,9 +73,9 @@ const zodErrorToValidationErrors = (error: z.ZodError): ValidationErrors => {
   return errors;
 };
 
-// ステップ1のバリデーション
-export const validateStep1 = (formData: FormData): ValidationErrors => {
-  const result = step1Schema.safeParse(formData);
+// 個人情報のバリデーション
+export const validatePersonalInfo = (formData: FormData): ValidationErrors => {
+  const result = personalInfoSchema.safeParse(formData);
   
   if (!result.success) {
     return zodErrorToValidationErrors(result.error);
@@ -84,9 +84,9 @@ export const validateStep1 = (formData: FormData): ValidationErrors => {
   return {};
 };
 
-// ステップ2のバリデーション
-export const validateStep2 = (formData: FormData): ValidationErrors => {
-  const result = step2Schema.safeParse(formData);
+// 連絡先情報のバリデーション
+export const validateContactInfo = (formData: FormData): ValidationErrors => {
+  const result = contactInfoSchema.safeParse(formData);
   
   if (!result.success) {
     return zodErrorToValidationErrors(result.error);


### PR DESCRIPTION
## Summary

ステップが前後する可能性を考慮し、コンポーネント名とバリデーション関数名からステップ番号を削除しました。

### 変更内容

#### コンポーネント名変更
- `Step1PersonalInfo` → `PersonalInfo`
- `Step2ContactInfo` → `ContactInfo`  
- `Step3Confirmation` → `Confirmation`

#### ファイル名変更
- `step1-personal-info.tsx` → `personal-info.tsx`
- `step2-contact-info.tsx` → `contact-info.tsx`
- `step3-confirmation.tsx` → `confirmation.tsx`

#### バリデーション関数・スキーマ名変更
- `validateStep1` → `validatePersonalInfo`
- `validateStep2` → `validateContactInfo`
- `step1Schema` → `personalInfoSchema`
- `step2Schema` → `contactInfoSchema`

#### 型名変更
- `Step1Data` → `PersonalInfoData`
- `Step2Data` → `ContactInfoData`

### 変更理由

1. **柔軟性の向上**: ステップの順序が変更されても、コンポーネント名を変更する必要がない
2. **意味的な明確性**: コンポーネントの機能が名前から直接理解できる
3. **保守性の向上**: ステップ番号に依存しない設計により、将来の変更に対応しやすい

### 影響範囲

- src/components/step-form/ 内のすべてのコンポーネント
- src/lib/step-form-types.ts のバリデーション関数とスキーマ
- src/components/ui/step-dialog.tsx のインポートと使用箇所
- テストファイルとREADME.mdの記述

### Test plan

- [ ] 既存の機能が正常に動作することを確認
- [ ] すべてのインポートが正しく解決されることを確認
- [ ] バリデーション機能が正常に動作することを確認
- [ ] TypeScriptのビルドエラーがないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)